### PR TITLE
Eliminate warnings in Swift DEVELOPMENT-SNAPSHOT-2016-05-09-a

### DIFF
--- a/Sources/HTTPStream.swift
+++ b/Sources/HTTPStream.swift
@@ -40,7 +40,7 @@ public final class HTTPStream: AsyncStream {
         }
     }
     
-    public func receive(upTo byteCount: Int = 2048 /* ignored */, timingOut deadline: Double = .never, completion result: (Void throws -> Data) -> Void) {
+    public func receive(upTo byteCount: Int = 2048 /* ignored */, timingOut deadline: Double = .never, completion result: ((Void) throws -> Data) -> Void) {
         stream.read { res in
             if case .Data(let buf) = res {
                 result { buf.data }

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -9,15 +9,15 @@
 let CRLF = "\r\n"
 
 extension Response {
-    public static func chunkedEncode(string string: String) -> Data {
+    public static func chunkedEncode(string: String) -> Data {
         return Data(chunkedEncode(data: Data(string)).map{ Byte($0) })
     }
     
-    public static func chunkedEncode(data data: Data) -> Data {
+    public static func chunkedEncode(data: Data) -> Data {
         return Data(chunkedEncode(bytes: data.signedBytes).map{ Byte($0) })
     }
     
-    public static func chunkedEncode(bytes bytes: [Int8]) -> [Int8] {
+    public static func chunkedEncode(bytes: [Int8]) -> [Int8] {
         var chunkedBytes = [Int8]()
         chunkedBytes.append(contentsOf: String(bytes.count, radix: 16).bytes)
         chunkedBytes.append(contentsOf: CRLF.bytes)


### PR DESCRIPTION
Remove duplicated parameter names and add parentheses to void functions